### PR TITLE
Add Create Store

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -13,6 +13,7 @@
     "mocha": true
   },
   "globals": {
-    "expect": true
+    "expect": true,
+    "sinon": true
   }
 }

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![NPM version](http://img.shields.io/npm/v/redux-mori.svg?style=flat-square)](https://www.npmjs.org/package/redux-mori)
 
-`redux-mori` is a drop-in replacement for Redux's [`combineReducers`](http://redux.js.org/docs/api/combineReducers.html) that works with [`mori.js`](http://swannodette.github.io/mori) immutable data structures.
+`redux-mori` is a drop-in replacement for Redux's [`combineReducers`](http://redux.js.org/docs/api/combineReducers.html) and [`createStore`](http://redux.js.org/docs/api/createStore.html) that works with [`mori.js`](http://swannodette.github.io/mori) immutable data structures.
 
 Any `preloadedState` for Redux's [`createStore`](https://github.com/reactjs/redux/blob/master/docs/api/createStore.md) should be a `mori` [`hashMap`](http://swannodette.github.io/mori/#hashMap).
 
@@ -10,14 +10,20 @@ Any `preloadedState` for Redux's [`createStore`](https://github.com/reactjs/redu
 
 If you create a store with `preloadedState`, make sure it is an instance of [`hashMap`]((http://swannodette.github.io/mori/#hashMap)):
 
+#### Create Store / Combine Reducers:
 ```js
 import { toClj } from 'mori';
-import { combineReducers } from 'redux-mori';
-import { createStore } from 'redux';
+import { combineReducers, createStore } from 'redux-mori';
 import fooReducer from './fooReducer';
 import bazReducer from './bazReducer';
 
 const preloadedState = toClj({foo: 'bar', baz: 'quux'});
 const rootReducer = combineReducers({fooReducer, bazReducer});
 const store = createStore(rootReducer, preloadedState);
+```
+
+#### Action:
+```js
+const ACTION_REQUEST = 'ACTION_REQUEST'
+const actionRequest = () => hashMap('type', ACTION_REQUEST)
 ```

--- a/flow/sinon.js
+++ b/flow/sinon.js
@@ -1,0 +1,1 @@
+declare var sinon: Function;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "redux-mori",
   "version": "0.0.3",
-  "description": "Drop-in replacement for Redux combineReducers that works with mori.js immutable data structures",
+  "description": "Drop-in replacement for Redux combineReducers and createStore that works with mori.js immutable data structures",
   "main": "./dist/index.js",
   "files": [
     "dist"

--- a/package.json
+++ b/package.json
@@ -55,6 +55,8 @@
     "eslint-plugin-standard": "^1.3.2",
     "mocha": "^2.5.3",
     "rimraf": "^2.5.2",
+    "sinon": "^1.17.4",
+    "sinon-chai": "^2.8.0",
     "webpack": "^1.13.1"
   }
 }

--- a/src/createStore.js
+++ b/src/createStore.js
@@ -1,0 +1,113 @@
+// @flow
+import { isMap, get, hashMap } from 'mori';
+import type { State, Action, Reducer, StoreEnhancer } from './types';
+
+export const ActionTypes = hashMap('INIT', '@@redux/INIT');
+
+export default function createStore (reducer: Reducer, preloadedState: ?State, enhancer: ?StoreEnhancer) {
+  if (typeof preloadedState === 'function' && typeof enhancer === 'undefined') {
+    enhancer = preloadedState;
+    preloadedState = undefined;
+  }
+
+  if (typeof enhancer !== 'undefined') {
+    if (typeof enhancer !== 'function') {
+      throw new Error('Expected the enhancer to be a function.');
+    }
+
+    return enhancer(createStore)(reducer, preloadedState);
+  }
+
+  if (typeof reducer !== 'function') {
+    throw new Error('Expected the reducer to be a function.');
+  }
+
+  let currentReducer = reducer;
+  let currentState = preloadedState;
+  let currentListeners = [];
+  let nextListeners = currentListeners;
+  let isDispatching = false;
+
+  const ensureCanMutateNextListeners = () => {
+    if (nextListeners === currentListeners) {
+      nextListeners = currentListeners.slice();
+    }
+  };
+
+  const getState = (): ?State => currentState;
+
+  const subscribe = (listener: Function) => {
+    if (typeof listener !== 'function') {
+      throw new Error('Expected listener to be a function.');
+    }
+
+    let isSubscribed = true;
+
+    ensureCanMutateNextListeners();
+    nextListeners.push(listener);
+
+    return () => {
+      if (!isSubscribed) {
+        return;
+      }
+
+      isSubscribed = false;
+
+      ensureCanMutateNextListeners();
+      const index = nextListeners.indexOf(listener);
+      nextListeners.splice(index, 1);
+    };
+  };
+
+  function dispatch (action: Action) {
+    if (!isMap(action)) {
+      throw new Error(
+        'Actions must be maps. ' +
+        'Use custom middleware for async actions.'
+      );
+    }
+
+    if (typeof get(action, 'type') === 'undefined') {
+      throw new Error(
+        'Actions may not have an undefined "type" property. ' +
+        'Have you misspelled a constant?'
+      );
+    }
+
+    if (isDispatching) {
+      throw new Error('Reducers may not dispatch actions.');
+    }
+
+    try {
+      isDispatching = true;
+      currentState = currentReducer(currentState, action);
+    } finally {
+      isDispatching = false;
+    }
+
+    var listeners = currentListeners = nextListeners;
+    for (var i = 0; i < listeners.length; i++) {
+      listeners[i]();
+    }
+
+    return action;
+  }
+
+  function replaceReducer (nextReducer: Reducer) {
+    if (typeof nextReducer !== 'function') {
+      throw new Error('Expected the nextReducer to be a function.');
+    }
+
+    currentReducer = nextReducer;
+    dispatch(hashMap('type', get(ActionTypes, 'INIT')));
+  }
+
+  dispatch(hashMap('type', get(ActionTypes, 'INIT')));
+
+  return {
+    dispatch,
+    subscribe,
+    getState,
+    replaceReducer,
+  };
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,1 +1,2 @@
+export createStore from './createStore';
 export combineReducers from './combineReducers';

--- a/src/types.js
+++ b/src/types.js
@@ -1,5 +1,14 @@
 // @flow
 export type State = {[key: string]: any};
-export type Action = { type: string };
+export type Action = () => any;
+export type Dispatch = (action: Action) => Action;
 export type Reducer = (state: ?State, action: Action) => State;
 export type Reducers = { [key: string]: Reducer };
+export type StoreCreator = (reducer: Reducer, preloadedState: ?State) => Store;
+export type StoreEnhancer = (next: StoreCreator) => StoreCreator;
+export type Store = {
+  dispatch: Dispatch,
+  getState: () => ?State,
+  subscribe: (listener: () => void) => () => void,
+  replaceReducer: (reducer: Reducer) => void,
+};

--- a/test.setup.js
+++ b/test.setup.js
@@ -1,4 +1,9 @@
 import 'babel-polyfill';
 import chai from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+
+chai.use(sinonChai);
 
 global.expect = chai.expect;
+global.sinon = sinon;

--- a/test/combineReducers.test.js
+++ b/test/combineReducers.test.js
@@ -18,7 +18,7 @@ describe('combineReducers()', () => {
         },
       });
 
-      const actual = rootReducer(initialState, {type: 'NONE'});
+      const actual = rootReducer(initialState, hashMap('type', 'NONE'));
       expect(actual.toString()).to.equal(initialState.toString());
     });
   });
@@ -37,7 +37,7 @@ describe('combineReducers()', () => {
         },
       });
 
-      const actual = rootReducer(initialState, {type: 'ADD'});
+      const actual = rootReducer(initialState, hashMap('type', 'ADD'));
       expect(getIn(actual, ['foo', 'count'])).to.equal(1);
     });
   });
@@ -66,7 +66,7 @@ describe('combineReducers()', () => {
         }),
       });
 
-      expect(rootReducer(undefined, {type: 'WHATEVS'}).toString()).to.eql(initialState.toString());
+      expect(rootReducer(undefined, hashMap('type', 'WHATEVS')).toString()).to.eql(initialState.toString());
     });
   });
 });

--- a/test/createStore.test.js
+++ b/test/createStore.test.js
@@ -3,7 +3,6 @@ import createStore from '../src/createStore';
 import combineReducers from '../src/combineReducers';
 import * as reducers from './fixtures/reducers';
 import { addTodo, unknownAction } from './fixtures/actionCreators';
-import type { State } from '../src/types';
 
 describe('createStore()', () => {
   context('initialized', () => {
@@ -68,13 +67,13 @@ describe('createStore()', () => {
   context('applying reducer to initial action', () => {
     it('should return correct initial state', () => {
       const store = createStore(reducers.todos, vector(
-        hashMap( 'id', 1, 'text', 'Hello')
+        hashMap('id', 1, 'text', 'Hello')
       ));
       const expected = vector(
         hashMap('id', 1, 'text', 'Hello')
       );
 
-      expect(equals(store.getState(), expected)).to.be.true
+      expect(equals(store.getState(), expected)).to.be.true;
     });
   });
 
@@ -102,7 +101,7 @@ describe('createStore()', () => {
         hashMap(
           'id', 2,
           'text', 'World'
-        )))).to.be.true
+        )))).to.be.true;
     });
   });
 
@@ -115,16 +114,16 @@ describe('createStore()', () => {
       store.replaceReducer(reducers.todosReverse);
 
       expect(equals(store.getState(), vector(
-        hashMap( 'id', 1, 'text', 'Hello'),
-        hashMap( 'id', 2, 'text', 'World')
+        hashMap('id', 1, 'text', 'Hello'),
+        hashMap('id', 2, 'text', 'World')
       ))).to.be.true;
 
       store.dispatch(addTodo('Top'));
 
       expect(equals(store.getState(), vector(
-        hashMap( 'id', 3, 'text', 'Top'),
-        hashMap( 'id', 1, 'text', 'Hello'),
-        hashMap( 'id', 2, 'text', 'World')
+        hashMap('id', 3, 'text', 'Top'),
+        hashMap('id', 1, 'text', 'Hello'),
+        hashMap('id', 2, 'text', 'World')
       ))).to.be.true;
 
       store.replaceReducer(reducers.todos);
@@ -132,10 +131,10 @@ describe('createStore()', () => {
       store.dispatch(addTodo('Bottom'));
 
       expect(equals(store.getState(), vector(
-        hashMap( 'id', 3, 'text', 'Top'),
-        hashMap( 'id', 1, 'text', 'Hello'),
-        hashMap( 'id', 2, 'text', 'World'),
-        hashMap( 'id', 4, 'text', 'Bottom')
+        hashMap('id', 3, 'text', 'Top'),
+        hashMap('id', 1, 'text', 'Hello'),
+        hashMap('id', 2, 'text', 'World'),
+        hashMap('id', 4, 'text', 'Bottom')
       ))).to.be.true;
     });
   });
@@ -164,7 +163,7 @@ describe('createStore()', () => {
       store.dispatch(unknownAction());
 
       expect(listenerA).to.have.been.calledOnce;
-      unsubscribeA()
+      unsubscribeA();
 
       store.dispatch(unknownAction());
       expect(listenerA).to.have.been.calledOnce;

--- a/test/createStore.test.js
+++ b/test/createStore.test.js
@@ -1,0 +1,173 @@
+import { equals, hashMap, vector } from 'mori';
+import createStore from '../src/createStore';
+import combineReducers from '../src/combineReducers';
+import * as reducers from './fixtures/reducers';
+import { addTodo, unknownAction } from './fixtures/actionCreators';
+import type { State } from '../src/types';
+
+describe('createStore()', () => {
+  context('initialized', () => {
+    it('exposes the public API', () => {
+      const rootReducer = combineReducers(reducers);
+      const store = createStore(rootReducer);
+
+      expect(store).to.have.all.keys(
+        'subscribe',
+        'dispatch',
+        'getState',
+        'replaceReducer'
+      );
+    });
+  });
+
+  context('reducer argument', () => {
+    it('throws when none', () => {
+      expect(() =>
+        createStore()
+      ).to.throw();
+    });
+
+    it('throws when string', () => {
+      expect(() =>
+        createStore('')
+      ).to.throw();
+    });
+
+    it('throws when map', () => {
+      expect(() =>
+        createStore(hashMap())
+      ).to.throw();
+    });
+
+    it('throws when vector', () => {
+      expect(() =>
+        createStore(vector())
+      ).to.throw();
+    });
+
+    it('does not throw when function', () => {
+      expect(() =>
+        createStore(() => hashMap())
+      ).to.not.throw();
+    });
+  });
+
+  context('initial state and action arguments', () => {
+    it('should return correct vector', () => {
+      const store = createStore(reducers.todos, vector(
+        hashMap('id', 1, 'text', 'foo')
+      ));
+      const expected = vector(
+        hashMap('id', 1, 'text', 'foo')
+      );
+
+      expect(equals(store.getState(), expected)).to.be.true;
+    });
+  });
+
+  context('applying reducer to initial action', () => {
+    it('should return correct initial state', () => {
+      const store = createStore(reducers.todos, vector(
+        hashMap( 'id', 1, 'text', 'Hello')
+      ));
+      const expected = vector(
+        hashMap('id', 1, 'text', 'Hello')
+      );
+
+      expect(equals(store.getState(), expected)).to.be.true
+    });
+  });
+
+  context('applying reducers to previous state', () => {
+    it('should return correct state', () => {
+      const store = createStore(reducers.todos);
+
+      expect(equals(store.getState(), vector())).to.be.true;
+      store.dispatch(unknownAction());
+
+      expect(equals(store.getState(), vector())).to.be.true;
+      store.dispatch(addTodo('Hello'));
+
+      expect(equals(store.getState(), vector(hashMap(
+        'id', 1,
+        'text', 'Hello'
+      )))).to.be.true;
+      store.dispatch(addTodo('World'));
+
+      expect(equals(store.getState(), vector(
+        hashMap(
+          'id', 1,
+          'text', 'Hello'
+        ),
+        hashMap(
+          'id', 2,
+          'text', 'World'
+        )))).to.be.true
+    });
+  });
+
+  context('replacing a reducer', () => {
+    it('should preserve state', () => {
+      const store = createStore(reducers.todos);
+      store.dispatch(addTodo('Hello'));
+      store.dispatch(addTodo('World'));
+
+      store.replaceReducer(reducers.todosReverse);
+
+      expect(equals(store.getState(), vector(
+        hashMap( 'id', 1, 'text', 'Hello'),
+        hashMap( 'id', 2, 'text', 'World')
+      ))).to.be.true;
+
+      store.dispatch(addTodo('Top'));
+
+      expect(equals(store.getState(), vector(
+        hashMap( 'id', 3, 'text', 'Top'),
+        hashMap( 'id', 1, 'text', 'Hello'),
+        hashMap( 'id', 2, 'text', 'World')
+      ))).to.be.true;
+
+      store.replaceReducer(reducers.todos);
+
+      store.dispatch(addTodo('Bottom'));
+
+      expect(equals(store.getState(), vector(
+        hashMap( 'id', 3, 'text', 'Top'),
+        hashMap( 'id', 1, 'text', 'Hello'),
+        hashMap( 'id', 2, 'text', 'World'),
+        hashMap( 'id', 4, 'text', 'Bottom')
+      ))).to.be.true;
+    });
+  });
+
+  context('single subscription', () => {
+    let store;
+
+    beforeEach(() => {
+      const rootReducer = combineReducers(reducers);
+      store = createStore(rootReducer);
+    });
+
+    it('should call listener correctly', () => {
+      const listenerA = sinon.spy(() => {});
+
+      store.subscribe(listenerA);
+      store.dispatch(unknownAction());
+
+      expect(listenerA).to.have.been.calledOnce;
+    });
+
+    it('should unsubscribe single listener correctly', () => {
+      const listenerA = sinon.spy(() => {});
+      const unsubscribeA = store.subscribe(listenerA);
+
+      store.dispatch(unknownAction());
+
+      expect(listenerA).to.have.been.calledOnce;
+      unsubscribeA()
+
+      store.dispatch(unknownAction());
+      expect(listenerA).to.have.been.calledOnce;
+    });
+  });
+});

--- a/test/fixtures/actionCreators.js
+++ b/test/fixtures/actionCreators.js
@@ -1,0 +1,9 @@
+import { inc, hashMap } from 'mori'
+import { ADD_TODO, UKNOWN_ACTION } from './actionTypes'
+
+export const addTodo = (text) =>
+  hashMap('type', ADD_TODO, 'text', text)
+
+export const unknownAction = () =>
+  hashMap('type', UKNOWN_ACTION)
+

--- a/test/fixtures/actionCreators.js
+++ b/test/fixtures/actionCreators.js
@@ -1,9 +1,9 @@
-import { inc, hashMap } from 'mori'
-import { ADD_TODO, UKNOWN_ACTION } from './actionTypes'
+import { hashMap } from 'mori';
+import { ADD_TODO, UKNOWN_ACTION } from './actionTypes';
 
 export const addTodo = (text) =>
-  hashMap('type', ADD_TODO, 'text', text)
+  hashMap('type', ADD_TODO, 'text', text);
 
 export const unknownAction = () =>
-  hashMap('type', UKNOWN_ACTION)
+  hashMap('type', UKNOWN_ACTION);
 

--- a/test/fixtures/actionTypes.js
+++ b/test/fixtures/actionTypes.js
@@ -1,2 +1,2 @@
-export const ADD_TODO = 'ADD_TODO'
-export const UKNOWN_ACTION = 'UNKNOWN_ACTION'
+export const ADD_TODO = 'ADD_TODO';
+export const UKNOWN_ACTION = 'UNKNOWN_ACTION';

--- a/test/fixtures/actionTypes.js
+++ b/test/fixtures/actionTypes.js
@@ -1,0 +1,2 @@
+export const ADD_TODO = 'ADD_TODO'
+export const UKNOWN_ACTION = 'UNKNOWN_ACTION'

--- a/test/fixtures/reducers.js
+++ b/test/fixtures/reducers.js
@@ -1,28 +1,28 @@
-import { into, reduceKV, inc, hashMap, get, vector } from 'mori'
-import { ADD_TODO } from './actionTypes'
+import { into, reduceKV, inc, hashMap, get, vector } from 'mori';
+import { ADD_TODO } from './actionTypes';
 
-const id = (state = vector()) => reduceKV(inc, 1, state)
+const id = (state = vector()) => reduceKV(inc, 1, state);
 
-export function todos(state = vector(), action) {
+export function todos (state = vector(), action) {
   switch (get(action, 'type')) {
     case ADD_TODO:
       return into(state, vector(hashMap(
         'id', id(state),
         'text', get(action, 'text')
-      )))
+      )));
     default:
-      return state
+      return state;
   }
 }
 
-export function todosReverse(state = [], action) {
+export function todosReverse (state = [], action) {
   switch (get(action, 'type')) {
     case ADD_TODO:
       return into(vector(hashMap(
         'id', id(state),
         'text', get(action, 'text')
-      )), state)
+      )), state);
     default:
-      return state
+      return state;
   }
 }

--- a/test/fixtures/reducers.js
+++ b/test/fixtures/reducers.js
@@ -1,0 +1,28 @@
+import { into, reduceKV, inc, hashMap, get, vector } from 'mori'
+import { ADD_TODO } from './actionTypes'
+
+const id = (state = vector()) => reduceKV(inc, 1, state)
+
+export function todos(state = vector(), action) {
+  switch (get(action, 'type')) {
+    case ADD_TODO:
+      return into(state, vector(hashMap(
+        'id', id(state),
+        'text', get(action, 'text')
+      )))
+    default:
+      return state
+  }
+}
+
+export function todosReverse(state = [], action) {
+  switch (get(action, 'type')) {
+    case ADD_TODO:
+      return into(vector(hashMap(
+        'id', id(state),
+        'text', get(action, 'text')
+      )), state)
+    default:
+      return state
+  }
+}


### PR DESCRIPTION
#### `createStore`

Proposal to add create store to allow the use of `hashMap` for an `Action` instead of a JavaScript Object Literal.
#### Added `devDependencies`
- Sinon dependency for `spy` when testing subscriptions to store
- Sinon Chai dependency to extend Chai with assertions
