### PR TITLE
Add redux logger with correct transform functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,18 @@ const store = createStore(rootReducer, preloadedState);
 const ACTION_REQUEST = 'ACTION_REQUEST'
 const actionRequest = () => hashMap('type', ACTION_REQUEST)
 ```
+
+Please note you can still use original redux `createStore` and write actions as JS objects, even if you're using `mori` in your state.
+
+## Logger
+If you're using Redux Logger and would like to get readable logs of state and actions, you can use our `createLogger` wrapper. You can use it exactly in the same way as the original but it presets following values:
+
+```js
+{
+  actionTransformer,
+  collapsed: true,
+  stateTransformer,
+}
+```
+
+Actions get transformed fully into JS if they are `mori` objects. If they are JS objects with only some values as `mori` structures, it will transform this data into JS as well.

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
   },
   "homepage": "https://github.com/redbadger/redux-mori#readme",
   "dependencies": {
-    "mori": "^0.3.2"
+    "mori": "^0.3.2",
+    "redux-logger": "^2.6.1"
   },
   "devDependencies": {
     "babel-cli": "^6.9.0",

--- a/src/createLogger.js
+++ b/src/createLogger.js
@@ -1,4 +1,6 @@
-import { createLogger as reduxLogger } from 'redux-logger';
+// @flow
+
+import reduxLogger from 'redux-logger';
 import { toJs, isCollection } from 'mori';
 
 export const stateTransformer = (state: Object): Object => toJs(state);
@@ -20,9 +22,9 @@ const getDefaultOptions = (): Object => ({
   stateTransformer,
 });
 
-const createLogger = (options: Object): Object => reduxLogger({
+const createLogger = (options: Object, logger: Function = reduxLogger): Object => logger({ // eslint-disable-line space-infix-ops
   ...getDefaultOptions(),
-  options,
+  ...options,
 });
 
 export default createLogger;

--- a/src/createLogger.js
+++ b/src/createLogger.js
@@ -1,0 +1,28 @@
+import { createLogger as reduxLogger } from 'redux-logger';
+import { toJs, isCollection } from 'mori';
+
+export const stateTransformer = (state: Object): Object => toJs(state);
+export const actionTransformer = (action: Object): Object => {
+  if (isCollection(action)) {
+    return toJs(action);
+  }
+
+  return Object.keys(action)
+    .reduce((acc, name) => ({
+      ...acc,
+      [name]: isCollection(action[name]) ? toJs(action[name]) : action[name],
+    }), {});
+};
+
+const getDefaultOptions = (): Object => ({
+  actionTransformer,
+  collapsed: true,
+  stateTransformer,
+});
+
+const createLogger = (options: Object): Object => reduxLogger({
+  ...getDefaultOptions(),
+  options,
+});
+
+export default createLogger;

--- a/test/createLogger.test.js
+++ b/test/createLogger.test.js
@@ -1,8 +1,29 @@
 // @flow
 import { hashMap, toJs } from 'mori';
-import { stateTransformer, actionTransformer } from '../src/createLogger';
+import createLogger, {
+  actionTransformer,
+  stateTransformer,
+} from '../src/createLogger';
 
 describe('create redux logger', () => {
+  context('create logger', () => {
+    it('merges default options with options from argument, creating redux logger', () => {
+      const logger = sinon.spy();
+      const options = {
+        collapsed: false,
+        another: 'option',
+      };
+      const expectedOptions = {
+        actionTransformer,
+        stateTransformer,
+        collapsed: false,
+        another: 'option',
+      };
+      createLogger(options, logger);
+      expect(logger).to.have.been.calledWith(expectedOptions);
+    });
+  });
+
   context('state transformation', () => {
     it('transforms state into js', () => {
       const initial = hashMap(

--- a/test/createLogger.test.js
+++ b/test/createLogger.test.js
@@ -1,0 +1,66 @@
+// @flow
+import { hashMap, toJs } from 'mori';
+import { stateTransformer, actionTransformer } from '../src/createLogger';
+
+describe('create redux logger', () => {
+  context('state transformation', () => {
+    it('transforms state into js', () => {
+      const initial = hashMap(
+        'user', hashMap(
+          'id', '123',
+          'name', 'Kadi'
+        ),
+        'profile', hashMap(
+          'address', hashMap(
+            'country', hashMap(
+              'code', 'ET',
+              'name', 'Estonia'
+            )
+          )
+        )
+      );
+      const expected = toJs(initial);
+      const actual = stateTransformer(initial);
+      expect(actual).to.deep.equal(expected);
+    });
+  });
+
+  context('action transformation', () => {
+    it('transforms action values to JS if they are a mori collection', () => {
+      const initial = {
+        type: 'LOGIN_SUCCESS',
+        user: hashMap(
+          'id', '345',
+          'name', 'Marcel',
+          'language', hashMap(
+            'code', 'en',
+            'name', 'English'
+          )
+        ),
+      };
+      const expected = {
+        type: 'LOGIN_SUCCESS',
+        user: toJs(initial.user),
+      };
+      const actual = actionTransformer(initial);
+      expect(actual).to.deep.equal(expected);
+    });
+
+    it('transforms actions into JS if they are a mori collection', () => {
+      const initial = hashMap(
+        'type', 'LOGIN_SUCCESS',
+        'user', hashMap(
+          'id', '345',
+          'name', 'Marcel',
+          'language', hashMap(
+            'code', 'en',
+            'name', 'English'
+          )
+        ),
+      );
+      const expected = toJs(initial);
+      const actual = actionTransformer(initial);
+      expect(actual).to.deep.equal(expected);
+    });
+  });
+});


### PR DESCRIPTION
Adds a wrapper for redux logger so that state and actions get logged out as JS objects.

Works if you're using mori actions and JS actions.
