### PR TITLE
Bug: Missing createLogger Export

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,2 +1,3 @@
 export createStore from './createStore';
 export combineReducers from './combineReducers';
+export createLogger from './createLogger';


### PR DESCRIPTION
Adds missing `createLogger` to `redux-mori` exports so it can be used within applications.
